### PR TITLE
Fix cancellation of async operation

### DIFF
--- a/Example/Operation-iOS.xcodeproj/project.pbxproj
+++ b/Example/Operation-iOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0C33E8B82D0103D60090096A /* OperationExecution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C33E8B72D0103D60090096A /* OperationExecution.swift */; };
 		0C8B0F702B84C15500A2A53F /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8B0F322B84C15500A2A53F /* Constants.swift */; };
 		0C8B0F712B84C15500A2A53F /* DummyNetworkMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8B0F342B84C15500A2A53F /* DummyNetworkMock.swift */; };
 		0C8B0F722B84C15500A2A53F /* emptyResponse.json in Resources */ = {isa = PBXBuildFile; fileRef = 0C8B0F352B84C15500A2A53F /* emptyResponse.json */; };
@@ -73,6 +74,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0C33E8B72D0103D60090096A /* OperationExecution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationExecution.swift; sourceTree = "<group>"; };
 		0C8B0F322B84C15500A2A53F /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		0C8B0F342B84C15500A2A53F /* DummyNetworkMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DummyNetworkMock.swift; sourceTree = "<group>"; };
 		0C8B0F352B84C15500A2A53F /* emptyResponse.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = emptyResponse.json; sourceTree = "<group>"; };
@@ -312,6 +314,7 @@
 			children = (
 				0C8B0F6E2B84C15500A2A53F /* CompoundOperationWrapperTests.swift */,
 				0C8B0F6F2B84C15500A2A53F /* OperationManagerTests.swift */,
+				0C33E8B72D0103D60090096A /* OperationExecution.swift */,
 			);
 			name = Operation;
 			path = ../../Tests/Operation;
@@ -623,6 +626,7 @@
 				0C8B0F7B2B84C15500A2A53F /* Entities.xcdatamodeld in Sources */,
 				0C8B0F892B84C15500A2A53F /* CoreDataServiceTests.swift in Sources */,
 				0C8B0F9D2B84C15500A2A53F /* CompoundOperationWrapperTests.swift in Sources */,
+				0C33E8B82D0103D60090096A /* OperationExecution.swift in Sources */,
 				0C8B0F7A2B84C15500A2A53F /* CDProject+CoreDataDecodable.swift in Sources */,
 				0C8B0F862B84C15500A2A53F /* CoreDataOperationHelper.swift in Sources */,
 				0C8B0F902B84C15500A2A53F /* DataProviderInterfaceTests.swift in Sources */,

--- a/Operation-iOS.podspec
+++ b/Operation-iOS.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Operation-iOS'
-  s.version          = '2.0.1'
+  s.version          = '2.1.0'
   s.summary          = 'Takes data from "rich" remote source and caches them in originaly "poor" local storage to speed up user interface.'
 
   s.description      = 'Library is aimed to solve a problem of providing persistent (cached) data while fresh one is being fetched from data source. Currently there are 3 types of data providers. DataProvider implementation is aimed to manage identifiable list of entities while SingleValueProvider deals with single objects. Finally, StreamableDataProvider is designed work with streamable data sources, for example, web sockets. Clients can subsribe for changes in data provider to update interface as soon as fresh data is fetched from the source. Currently, there is a single implementation of local storage based on Core Data. Interaction with the library occurs via native Operation concept to simplify chaining and dependency management.'

--- a/Operation-iOS/Classes/Operations/Base/AsyncClosureOperation.swift
+++ b/Operation-iOS/Classes/Operations/Base/AsyncClosureOperation.swift
@@ -17,7 +17,9 @@ open class AsyncClosureOperation<ResultType>: BaseOperation<ResultType> {
     }
 
     open override func cancel() {
-        cancelationClosure?()
+        if isExecuting {
+            cancelationClosure?()
+        }
         
         super.cancel()
     }

--- a/Operation-iOS/Classes/Operations/Base/BaseOperation.swift
+++ b/Operation-iOS/Classes/Operations/Base/BaseOperation.swift
@@ -160,13 +160,11 @@ open class BaseOperation<ResultType>: Operation {
     open override func main() {
         do {
             try performAsync { operationResult in
-                self.result = operationResult
-                self.finish()
+                self.completeWithResultIfExecuting(operationResult)
             }
 
         } catch {
-            result = .failure(error)
-            finish()
+            completeWithResultIfExecuting(.failure(error))
         }
     }
     
@@ -174,10 +172,21 @@ open class BaseOperation<ResultType>: Operation {
         configurationBlock = nil
         
         super.cancel()
+        
+        finish()
     }
 
     open func performAsync(_ callback: @escaping (Result<ResultType, Error>) -> Void) throws {
         fatalError("Must be overriden by subsclass")
+    }
+ 
+    func completeWithResultIfExecuting(_ result: Result<ResultType, Error>) {
+        guard isExecuting else {
+            return
+        }
+        
+        self.result = result
+        finish()
     }
     
     func finish() {

--- a/Tests/Operation/OperationExecution.swift
+++ b/Tests/Operation/OperationExecution.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import Operation_iOS
+
+final class OperationExecution: XCTestCase {
+
+    func testFinishOperationWhenCancelled() {
+        let operation = AsyncClosureOperation<Void> { completion in
+            // operation never completes
+        }
+        
+        let operationQueue = OperationQueue()
+        
+        let expectation = XCTestExpectation()
+        
+        operation.completionBlock = {
+            expectation.fulfill()
+        }
+        
+        operationQueue.addOperation(operation)
+        
+        DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(3)) {
+            operation.cancel()
+        }
+        
+        wait(for: [expectation], timeout: 10)
+    }
+    
+    func testExecutingCancelledOperation() {
+        let operation1 = ClosureOperation<Void> {}
+        
+        let operation2 = ClosureOperation<Void> {
+            operation1.cancel()
+        }
+        
+        operation1.addDependency(operation2)
+        
+        let operationQueue = OperationQueue()
+        
+        let expectation = XCTestExpectation()
+        
+        operation1.completionBlock = {
+            expectation.fulfill()
+        }
+        
+        operationQueue.addOperations([operation2, operation1], waitUntilFinished: false)
+        
+        wait(for: [expectation], timeout: 10)
+    }
+}


### PR DESCRIPTION
## Purpose

Currently, if operation is cancelled for some cases it doesn't move to the finished state as [Apple Documentation ](https://developer.apple.com/documentation/foundation/operation/1408418-iscancelled) suggests: for example, when AsyncOperation doesn't call completion closure after cancellation for already started operation. The PR fixes the issue.